### PR TITLE
fixed aspect ratio issue for about.html

### DIFF
--- a/tufts_chess_website/about.html
+++ b/tufts_chess_website/about.html
@@ -61,9 +61,11 @@
         <h3>Tufts Chess Club</h3>
         <p>The Tufts Chess Club aims to provide any members of the Tufts Community wishing to play chess with a forum in which to do so. It also aims to teach a basic understanding of the rules of chess to beginning players as well as critical analysis of the tactics of the game to more advanced players. To facilitate the exchange of information among chess-playing members of the Tufts Community so that anyone wishing to do so may find an opponent to play and to improve their skills outside of meetings of the Tufts Chess Club as well as at meetings.</p>
         <br>
-        <img src="https://cdn.pixabay.com/photo/2017/09/08/20/29/chess-2730034_1280.jpg" class="images">
-        <img src="https://www.chess.com/share/club/tufts-chess-club" class="images">
-        <img src="https://media.istockphoto.com/id/1312425777/photo/digital-tablet-with-chess-app-on-screen.jpg?s=612x612&w=0&k=20&c=gdfo1ZodhDSP7jKLmRfkOQAJeWmJ5sH4LeMie2-J2hM=" class="images">
+        <div class="sidebysidecontainer">
+            <img src="https://cdn.pixabay.com/photo/2017/09/08/20/29/chess-2730034_1280.jpg">
+            <img src="https://www.chess.com/share/club/tufts-chess-club">
+            <img src="https://media.istockphoto.com/id/1312425777/photo/digital-tablet-with-chess-app-on-screen.jpg?s=612x612&w=0&k=20&c=gdfo1ZodhDSP7jKLmRfkOQAJeWmJ5sH4LeMie2-J2hM=">
+        </div>
 
     </div>
 

--- a/tufts_chess_website/styles.css
+++ b/tufts_chess_website/styles.css
@@ -235,11 +235,24 @@ footer .row::after {
     clear: both;
 }
 
-.images{
-    margin-left: 40px;
-    height: 290px;
-    width: 290px;
-    margin-right: 120px;
+.sidebysidecontainer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    max-width: 200%;
+    margin: 0 auto;
+    height: 250px;
+}
+
+.sidebysidecontainer img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    flex: 1;
+    margin: 5px;
+    /*margin-left: 40px;
+    margin-right: 120px;*/
 }
 
 .container{


### PR DESCRIPTION
The old about.html forced the images at the bottom to take the same aspect ratio, I created a sidebyside container that allows the three images to be centered vertically and horizontally, but allows each image to keep its original aspect ratio. No other images were of class="images" so I removed it.

Here's what it looks like now:
![image](https://github.com/edwardl903/tufts_chess/assets/36905002/0b30ceb9-2b03-4435-ba9f-78591be87215)
